### PR TITLE
expose seperated import paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 node_modules
 dist
 npm-debug.log
+package-lock.json
+/*.js
+/*.d.ts
+!wallaby.js
+!protractor.conf.js

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {
-    "build": "rm -rf dist && (tsc -p . || true) && npm run build-testsuite",
+    "build": "rm -rf dist && (tsc -p . || true) && npm run build-testsuite && npm run expose-adapters",
     "build-testsuite": "cp src/test-suite/index.ejs dist/test-suite/index.ejs && browserify dist/test-suite/app.js > dist/test-suite/bundle.js",
     "testsuite-server": "node dist/test-suite/server.js",
-    "test": "bash support/test.sh"
+    "test": "bash support/test.sh",
+    "expose-adapters": "import-path --path lib --dts"
   },
   "author": "Wix.com",
   "license": "MIT",
@@ -27,6 +28,7 @@
     "concurrently": "^3.5.1",
     "ejs": "^2.5.7",
     "express": "^4.16.2",
+    "import-path": "^1.0.3",
     "jsdom": "^11.10.0",
     "jsdom-global": "^3.0.2",
     "mocha": "^4.1.0",


### PR DESCRIPTION
This pr closes https://github.com/wix-incubator/unidriver/issues/2

The idea here is to use https://github.com/wix/import-path package on build time.
This package helps to create a nicer API for the desired paths.

Now in order to use puppeteer, a consumer should do:
```js
import { pupUniDriver } from 'unidriver/puppeteer';
import { reactUniDriver } from 'unidriver/react';
```

