### PR TITLE
puppeteer: allow Frame to be BaseElementContainer

### DIFF
--- a/adapters/puppeteer/src/index.ts
+++ b/adapters/puppeteer/src/index.ts
@@ -1,7 +1,7 @@
 import { Locator, UniDriverList, UniDriver, MapFn, waitFor, NoElementWithLocatorError, MultipleElementsWithLocatorError, isMultipleElementsWithLocatorError } from '@unidriver/core';
-import { ElementHandle, Page } from 'puppeteer';
+import { ElementHandle, Page, Frame } from 'puppeteer';
 
-type BaseElementContainer = { page: Page; selector: string };
+type BaseElementContainer = { page: Page | Frame; selector: string };
 type ElementContainer = BaseElementContainer & { element: ElementHandle | null };
 type ElementsContainer = BaseElementContainer & { elements: ElementHandle[] };
 


### PR DESCRIPTION
Needed to pass `Frame` to `pupUniDriver` when writing https://github.com/wix-private/cashier-client/pull/287 and tripped the type checker (resulting in ugly [`as any as Page`](https://github.com/wix-private/cashier-client/pull/287/files#diff-f6e15f4a7cf58ec345fdbde9d8f918a1R24))

Adapter only uses `.$eval()` and `.$()`, so `Frame` should be usable

_Are there other reasons for `BaseElementContainer` to require `Page` and not `Page | Frame`?.._ 🤔