### PR TITLE
fix travis-ci tests; explicitly use `xenial`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ language: node_js
 node_js:
 - 10
 sudo: required
+dist: xenial
+services:
+  - xvfb
 addons:
   chrome: stable
 install:
 - npm install
 - npm run bootstrap
-before_script:
-- export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
 script:
 - npm run build
 - npm run test


### PR DESCRIPTION
https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-services

`xenial` is already used implicitly, but because using `xvfb` via `services` requires it (xenial), it may be safer to be more explicit