### PR TITLE
jsdom-react: simulate click events in the correct order

### DIFF
--- a/adapters/jsdom-react/src/index.ts
+++ b/adapters/jsdom-react/src/index.ts
@@ -116,8 +116,6 @@ export const jsdomReactUniDriver = (containerOrFn: ElementOrElementFinder): UniD
 			// 15 - https://github.com/facebook/react/blob/v15.6.1/src/renderers/dom/client/syntheticEvents/SyntheticMouseEvent.js#L45
 			// 16 - https://github.com/facebook/react/blob/master/packages/react-dom/src/events/SyntheticMouseEvent.js#L33
 			Simulate.mouseDown(el, eventData);
-			Simulate.mouseUp(el, eventData);
-			Simulate.click(el, eventData);
 
 			if (elementIsFocusable(el)) {
 				if (document.activeElement != el) {
@@ -131,6 +129,9 @@ export const jsdomReactUniDriver = (containerOrFn: ElementOrElementFinder): UniD
 					}
 				}
 			}
+
+			Simulate.mouseUp(el, eventData);
+			Simulate.click(el, eventData);
 		},
 		mouse: {
 			press: async() => {

--- a/adapters/jsdom-react/src/spec.tsx
+++ b/adapters/jsdom-react/src/spec.tsx
@@ -111,6 +111,35 @@ describe('react base driver specific tests', () => {
 			assert(focus.calledOnce);
 		});
 
+		it('should trigger [mousedown, focus, mouseup, click] events on click', async () => {
+			// https://jsbin.com/larubagiwu/1/edit?html,js,console,output
+			// https://github.com/wix-incubator/unidriver/pull/86#issuecomment-516809527
+			const cleanJsdom = require('jsdom-global')();
+			const mousedown = spy();
+			const focus = spy();
+			const mouseup = spy();
+			const click = spy();
+			const elem = document.createElement('div');
+			const btn = (
+				<button onMouseDown={mousedown} onFocus={focus} onMouseUp={mouseup} onClick={click}>
+					bob
+				</button>
+				);
+			ReactDOM.render(btn, elem);
+	
+			const driver = jsdomReactUniDriver(elem);
+	
+			await driver.$('button').click();
+			cleanJsdom();
+
+			sinon.assert.callOrder(mousedown, focus, mouseup, click);
+
+			assert(mousedown.calledOnce);
+			assert(focus.calledOnce);
+			assert(mouseup.calledOnce);
+			assert(click.calledOnce);
+		});
+
 		it('should trigger [focusA, blurA, focusB] when clicking two buttons', async () => {
 			const cleanJsdom = require('jsdom-global')();
 			const focusA = spy();

--- a/adapters/selenium/package.json
+++ b/adapters/selenium/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@unidriver/core": "^1.1.3",
-    "chromedriver": "^2.46.0",
+    "chromedriver": "^76.0.0",
     "selenium-webdriver": "^3.6.0"
   },
   "devDependencies": {

--- a/examples/package.json
+++ b/examples/package.json
@@ -22,7 +22,7 @@
     "@unidriver/puppeteer": "^1.1.6",
     "@unidriver/selenium": "^1.1.5",
     "browserify": "^16.0.0",
-    "chromedriver": "^2.46.0",
+    "chromedriver": "^76.0.0",
     "express": "^4.16.0",
     "find-free-port-sync": "^1.0.0",
     "jsdom": "^13.2.0",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "test-no-bail": "lerna run --stream --no-bail test",
     "clean": "lerna clean -y",
     "release": "lerna publish",
-	"start": "npm run bootstrap && npm run build && npm run test",
-	"prerelease": "npm run build && npm run test"
+    "start": "npm run bootstrap && npm run build && npm run test",
+    "prerelease": "npm run build && npm run test"
   },
   "author": "Wix.com",
   "license": "MIT",


### PR DESCRIPTION
see also:
- https://jsbin.com/larubagiwu/1/edit?html,js,console,output
- https://github.com/wix-incubator/unidriver/pull/86#issuecomment-516809527

---

to install adapter from the branch as a dependency for package `A`:
- clone the repo
- check out the branch
- run `npm run build && npm test && cd adapters/jsdom-react && npm pack`, notice newly created `.tgz` archive
- `cd` to your package `A` and run `npm i [path-to-the-tgz]`