### PR TITLE
fix GitHub rate limits when updating protractor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
 install:
 - npm install
 - npm run bootstrap
+- node_modules/protractor/bin/webdriver-manager update --github_token=$PROTRACTOR_GITHUB_TOKEN
 script:
 - npm run build
 - npm run test

--- a/adapters/protractor/package.json
+++ b/adapters/protractor/package.json
@@ -16,7 +16,7 @@
 		"selenium-webdriver": "^3.6.0"
 	},
 	"peerDependencies": {
-		"protractor": "^5.4.2 || ^6.0.0"
+		"protractor": "^6.0.0"
 	},
 	"devDependencies": {
 		"@unidriver/test-suite": "^1.1.5",

--- a/adapters/protractor/package.json
+++ b/adapters/protractor/package.json
@@ -6,7 +6,8 @@
 	"typings": "dist/index.d.ts",
 	"scripts": {
 		"build": "rm -rf dist && tsc -p .",
-		"test": "webdriver-manager update && protractor ./dist/protractor.conf.js"
+		"pretest": "test $CI || webdriver-manager update",
+		"test": "protractor ./dist/protractor.conf.js"
 	},
 	"author": "Wix.com",
 	"license": "MIT",
@@ -15,10 +16,10 @@
 		"selenium-webdriver": "^3.6.0"
 	},
 	"peerDependencies": {
-		"protractor": "^5.4.2"
+		"protractor": "^5.4.2 || ^6.0.0"
 	},
 	"devDependencies": {
 		"@unidriver/test-suite": "^1.1.5",
-		"protractor": "^5.4.2"
+		"protractor": "^6.0.0"
 	}
 }

--- a/adapters/protractor/src/index.ts
+++ b/adapters/protractor/src/index.ts
@@ -116,7 +116,7 @@ export const protractorUniDriver = (
     hover: async () => {
       const e = await safeElem();
 
-      return (await e.browser_.actions().mouseMove(e).perform());
+      return (await e.browser_.actions().move({ origin: await e.getWebElement() }).perform());
     },
 		pressKey: async(key: string) => {
       const el = await safeElem();
@@ -139,16 +139,16 @@ export const protractorUniDriver = (
     mouse: {
 			press: async() => {
         const e = await safeElem();
-        return (await e.browser_.actions().mouseDown(e).perform());
+        return (await e.browser_.actions().move({origin: await e.getWebElement()}).press().perform());
 			},
 			release: async () => {
         const e = await safeElem();
-        return (await e.browser_.actions().mouseUp(e).perform());
+        return (await e.browser_.actions().move({origin: await e.getWebElement()}).release().perform());
       },
       moveTo: async (to) => {
         const e = await safeElem();
         const nativeElem = await to.getNative();
-        await (await e.browser_.actions().mouseMove(nativeElem).perform());
+        await (await e.browser_.actions().move({origin: await nativeElem.getWebElement()}).perform());
       }
 		},
     exists,
@@ -156,7 +156,7 @@ export const protractorUniDriver = (
       const el = await safeElem();
 
       const retValue: boolean =
-        await browser.executeScript<boolean>(
+        await browser.executeScript(
           'const elem = arguments[0], ' +
           '			box = elem.getBoundingClientRect(), ' +
           '			cx = box.left + box.width / 2, ' +

--- a/adapters/protractor/src/protractor.conf.ts
+++ b/adapters/protractor/src/protractor.conf.ts
@@ -7,8 +7,8 @@ let server: Server;
 
 exports.config = {
   framework: 'jasmine',
-  onPrepare() {
-    browser.ignoreSynchronization = true;
+  onPrepare: async () => {
+    await browser.waitForAngularEnabled(false);
   },
   capabilities: {
     'browserName': 'chrome'

--- a/adapters/selenium/package.json
+++ b/adapters/selenium/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@unidriver/core": "^1.1.3",
-    "chromedriver": "^2.46.0",
+    "chromedriver": "^76.0.0",
     "selenium-webdriver": "^3.6.0"
   },
   "devDependencies": {

--- a/examples/package.json
+++ b/examples/package.json
@@ -22,7 +22,7 @@
     "@unidriver/puppeteer": "^1.1.6",
     "@unidriver/selenium": "^1.1.5",
     "browserify": "^16.0.0",
-    "chromedriver": "^2.46.0",
+    "chromedriver": "^76.0.0",
     "express": "^4.16.0",
     "find-free-port-sync": "^1.0.0",
     "jsdom": "^13.2.0",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "test-no-bail": "lerna run --stream --no-bail test",
     "clean": "lerna clean -y",
     "release": "lerna publish",
-	"start": "npm run bootstrap && npm run build && npm run test",
-	"prerelease": "npm run build && npm run test"
+    "start": "npm run bootstrap && npm run build && npm run test",
+    "prerelease": "npm run build && npm run test"
   },
   "author": "Wix.com",
   "license": "MIT",


### PR DESCRIPTION
to pass `--github_token` arg, had to update `protractor` to 6.0.0, which is now dependent on newer version of `selenium-webdriver`

I added my own GitHub [token](https://github.com/settings/tokens) (with `public_repo` permission) to [travis-ci](https://travis-ci.org/wix-incubator/unidriver/settings). Feel free to replace it with someone else's