### PR TITLE
Pass event target to change event simulate

### DIFF
--- a/adapters/jsdom-react/src/index.ts
+++ b/adapters/jsdom-react/src/index.ts
@@ -204,8 +204,10 @@ export const jsdomReactUniDriver = (containerOrFn: ElementOrElementFinder): UniD
 		hasClass: async (className: string) => (await elem()).classList.contains(className),
 		enterValue: async (value: string) => {
 			const el = (await elem()) as HTMLInputElement;
-			el.value = value;
-			Simulate.change(el);
+			const { name, type } = el;
+			Simulate.change(el, {
+				target: { name, type, value } as HTMLInputElement
+			});
 		},
 		attr: async (name: string) => {
 			const el = await elem();

--- a/adapters/jsdom-react/src/spec.tsx
+++ b/adapters/jsdom-react/src/spec.tsx
@@ -240,5 +240,34 @@ describe('react base driver specific tests', () => {
 			assert(focusB.notCalled);
 		});
 	})
-	
+
+	describe('enterValue', () => {
+		it('should set event target properly', async () => {
+			const cleanJsdom = require('jsdom-global')();
+			const change = spy();
+			const elem = document.createElement('div');
+			const input = (
+				<input
+					type="text"
+					name="search"
+					onChange={change}
+				/>
+			);
+
+			ReactDOM.render(input, elem);
+
+			const driver = jsdomReactUniDriver(elem);
+
+			await driver.$('input').enterValue('some keywords');
+			assert(change.calledOnce);
+
+			const eventTarget = change.args[0][0].target;
+			assert.equal(eventTarget.name, "search");
+			assert.equal(eventTarget.type, "text");
+			assert.equal(eventTarget.value, "some keywords");
+
+			cleanJsdom();
+		})
+	})
+
 });


### PR DESCRIPTION
@GabiGrin  @borisd9
Motivation of this change is to be able to test the params around the text enter, like here for example:
https://github.com/wix/wix-style-react/blob/0504dbb1f4192fe68ded2f1f6496f2b4d56d2a24/src/Input/Input.spec.js#L116

https://github.com/wix/wix-style-react/blob/0504dbb1f4192fe68ded2f1f6496f2b4d56d2a24/src/MultiSelect/MultiSelect.spec.js#L128