### PR TITLE
Puppeteer - use Page.evaluate instead of Page.$eval

### DIFF
--- a/adapters/puppeteer/src/index.ts
+++ b/adapters/puppeteer/src/index.ts
@@ -169,12 +169,12 @@ export const pupUniDriver = (
             return value || '';
         },
         attr: async name => {
-            const { page, selector } = await elem();
-            return page.$eval(
-                selector,
-                (elem, name) => {
-                    return elem.getAttribute(name);
+            const { page, element } = await elem();
+            return page.evaluate(
+                (elem:any, n) => {
+                    return elem.getAttribute(n);
                 },
+                element,
                 name
             );
         },
@@ -235,13 +235,12 @@ export const pupUniDriver = (
         },
         getNative: elem,
         _prop: async (name: string) => {
-            const { page, selector } = await elem();
-            return page.$eval(
-              selector,
-              (elem: any, name) => {
-                  return elem[name];
+            const { page, element } = await elem();
+            return page.evaluate(
+              (elem: any, n) => {
+                  return elem[n];
               },
-              name
+              element, name
             );
         },
     };

--- a/test-suite/src/app/react/todo-app/index.tsx
+++ b/test-suite/src/app/react/todo-app/index.tsx
@@ -22,6 +22,7 @@ class TodoAppItem extends React.Component<TodoItemProps, {}> {
 
 		return (
 			<div className={`todo-item ${cn}`} onMouseEnter={onHover} onMouseLeave={onBlur} data-value={item.id} style={style}>
+				<input type="checkbox" checked={item.completed} />
 				<span className='label'>{item.label}</span>
 				{item.completed ? <span className='completed'>Completed!</span> : null}
 				<button className='toggle' onClick={onToggle}>Toggle</button>
@@ -52,7 +53,7 @@ export class TodoApp extends React.Component<TodoAppProps, TodoAppState> {
 
 	onChange = (e: any) => {
 		this.setState({newItem: e.target.value});
-	}
+	};
 
 	onAdd = () => {
 		const items = this.state.items;
@@ -91,7 +92,7 @@ export class TodoApp extends React.Component<TodoAppProps, TodoAppState> {
 					{itemsComp}
 				</main>
 				<footer>
-					<input type="checkbox" checked></input>Mark all as completed<br/>
+					<input type="checkbox" checked />Mark all as completed<br/>
 					Items count: <span className='count'>{items.length}</span>
 				</footer>
 			</div>);

--- a/test-suite/src/app/svelte/Todo/TodoItem.svelte
+++ b/test-suite/src/app/svelte/Todo/TodoItem.svelte
@@ -16,6 +16,7 @@
      on:mouseleave={onBlur}
      data-value={item.id}
 >
+    <input type="checkbox" checked={item.completed} />
     <span class='label'>{item.label}</span>
     {#if item.completed}
         <span class='completed'>Completed!</span>

--- a/test-suite/src/run-test-suite.ts
+++ b/test-suite/src/run-test-suite.ts
@@ -226,7 +226,7 @@ export const runTestSuite = (params: TestSuiteParams) => {
             });
           });
 
-          it('should correct prop for items in list', async () => {
+          it('returns the correct prop for items in list', async () => {
             const items = [
                 itemCreator({ label: 'Bob', completed: false }),
                 itemCreator({ label: 'Alice', completed: true })

--- a/test-suite/src/run-test-suite.ts
+++ b/test-suite/src/run-test-suite.ts
@@ -187,10 +187,13 @@ export const runTestSuite = (params: TestSuiteParams) => {
 
             it('returns attribute value', async () => {
                 const items = [
-                    itemCreator({ label: 'Bob', completed: false, id: 'bob' })
+                    itemCreator({ label: 'Bob', completed: false, id: 'bob' }),
+                    itemCreator({ label: 'Alice', completed: false, id: 'alice' })
                 ];
                 await runTest({ items }, async driver => {
-                    assert.deepEqual(await driver.$('.todo-item').attr('data-value'), 'bob');
+                    const items = driver.$$('.todo-item');
+                    assert.deepEqual(await items.get(0).attr('data-value'), 'bob');
+                    assert.deepEqual(await items.get(1).attr('data-value'), 'alice');
                 });
             });
 
@@ -222,7 +225,19 @@ export const runTestSuite = (params: TestSuiteParams) => {
               assert.equal(await driver.$('footer input')._prop('checked'), true);
             });
           });
-        })
+
+          it('should correct prop for items in list', async () => {
+            const items = [
+                itemCreator({ label: 'Bob', completed: false }),
+                itemCreator({ label: 'Alice', completed: true })
+            ];
+            await runTest({items}, async (driver) => {
+              const checkboxes = driver.$$('.todo-item input');
+              assert.equal(await checkboxes.get(0)._prop('checked'), false);
+              assert.equal(await checkboxes.get(1)._prop('checked'), true);
+            });
+          });
+        });
 
 		it('rejects with the right error on action when an element does not exist given locator', async () => {
 			await runTest({items: []}, async (driver) => {


### PR DESCRIPTION
`Page.$eval` just always gets the first element that matches the selector. So when the selector should return a list of elements (i.e. using `UniDriver.$$('...')[1]._prop('...')`), we just take the first element instead. We already have the correct element at this point so we don't need a selector, really. I changed the `Page.$eval` usage to `Page.evaluate` and pass it the element which we can take from `elem()`.
