### PR TITLE
Set native value for uncontrolled input on enterValue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,7 @@ dist: xenial
 services:
   - xvfb
 addons:
-  chrome: stable
-before_script:
-  - LATEST_CHROMEDRIVER_VERSION=`curl -s "https://chromedriver.storage.googleapis.com/LATEST_RELEASE"`
-  - curl "https://chromedriver.storage.googleapis.com/${LATEST_CHROMEDRIVER_VERSION}/chromedriver_linux64.zip" -O
-  - unzip chromedriver_linux64.zip -d ~/bin
+  chrome: beta
 install:
 - npm install
 - npm run bootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ services:
   - xvfb
 addons:
   chrome: stable
+before_script:
+  - LATEST_CHROMEDRIVER_VERSION=`curl -s "https://chromedriver.storage.googleapis.com/LATEST_RELEASE"`
+  - curl "https://chromedriver.storage.googleapis.com/${LATEST_CHROMEDRIVER_VERSION}/chromedriver_linux64.zip" -O
+  - unzip chromedriver_linux64.zip -d ~/bin
 install:
 - npm install
 - npm run bootstrap

--- a/adapters/jsdom-react/src/index.ts
+++ b/adapters/jsdom-react/src/index.ts
@@ -205,9 +205,13 @@ export const jsdomReactUniDriver = (containerOrFn: ElementOrElementFinder): UniD
 		},
 		hasClass: async (className: string) => (await elem()).classList.contains(className),
 		enterValue: async (value: string) => {
-			const el = (await elem()) as HTMLInputElement;
-			const { name, type } = el;
-			Simulate.change(el, {
+			const el = (await elem()) as JSX.IntrinsicElements['input'];
+			const { name, type, onChange } = el;
+			// Set native value for uncontrolled component
+			if (!onChange) {
+			  el.value = value;
+			}
+			Simulate.change(el as Element, {
 				target: { name, type, value } as HTMLInputElement
 			});
 		},

--- a/adapters/jsdom-react/src/spec.tsx
+++ b/adapters/jsdom-react/src/spec.tsx
@@ -292,7 +292,29 @@ describe('react base driver specific tests', () => {
 			assert.equal(eventTarget.value, "some keywords");
 
 			cleanJsdom();
-		})
+		});
+		
+		it('works with uncontrolled inputs', async () => {
+			const cleanJsdom = require('jsdom-global')();
+			const elem = document.createElement('div');
+			const input = (
+				<input
+					type="text"
+					name="search"
+				/>
+			);
+
+			ReactDOM.render(input, elem);
+
+			const driver = jsdomReactUniDriver(elem);
+
+			await driver.$('input').enterValue('some keywords');
+
+			const inputValue = await driver.$('input').value();
+			assert.equal(inputValue, "some keywords");
+
+			cleanJsdom();
+		});
 	})
 
 });


### PR DESCRIPTION
Reported on:
https://wix.slack.com/archives/C39FTGUBZ/p1603006532288200

https://github.com/facebook/react/issues/3151#issuecomment-74943529
`TestUtils.Simulate doesn't actually fire the native event. So if your component doesn't do anything with the event (in this case our input wrapper doesn't) then the actual DOM node won't be updated.`

This changes value of input in the enterValue method if there is no onChange controller to control the input's value,
due to TestUtils.Simulate not firing native events in jsdom-react environments.