### PR TITLE
Enter value e2e vs unit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ dist: xenial
 services:
   - xvfb
 addons:
-  chrome: stable
+  chrome: beta
 install:
 - npm install
 - npm run bootstrap

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "bootstrap": "lerna bootstrap --hoist",
     "build": "lerna run --stream build",
-    "test": "lerna run --stream test",
+    "test": "lerna run --stream --no-bail test",
     "test-no-bail": "lerna run --stream --no-bail test",
     "clean": "lerna clean -y",
     "release": "lerna publish",

--- a/test-suite/src/run-test-suite.ts
+++ b/test-suite/src/run-test-suite.ts
@@ -74,6 +74,12 @@ export const runTestSuite = (params: TestSuiteParams) => {
                     assert.equal(await driver.$('header input').value(), 'hey there');
                 });
             });
+            it('append value to existing value', async () => {
+                await runTest({items: [], initialText: 'Hello '}, async (driver) => {
+                    await driver.$('header input').enterValue('World!');
+                    assert.equal(await driver.$('header input').value(), 'Hello World!');
+                });
+            });
         });
 
         describe('click()', () => {


### PR DESCRIPTION
It seems that the enterValue method will have different effects in unit tests than in e2e tests.

Given input value of Hello 
after doing enterValue("World!")
unit tests will produce input value of "World!" 
while e2e test will produce "Hello World!"

In jsdom-react we receive value and use Simulate.change to replace the input’s value to value

In puppeteer we use type and in protractor/selenium we use sendKeys , all of which will append value to the current input’s value