### PR TITLE
Target ES2017 to avoid transpiling async/await

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es5",
+        "target": "ES2017",
         "strict": true,
         "noImplicitAny": true,
         "noImplicitReturns": true,


### PR DESCRIPTION
For easier debugging of async stacktraces.

I'm not sure what platforms are we targeting, but node has async/await since 7.6 IIRC.
Still, perhaps this warrants a major version bump. @GabiGrin WDYT?