### PR TITLE
Improve `wait` error message

### DIFF
--- a/adapters/puppeteer/src/spec.ts
+++ b/adapters/puppeteer/src/spec.ts
@@ -18,7 +18,7 @@ let page: Page;
 
 const beforeFn = async () => {
   const args = process.env.CI ? ['--no-sandbox'] : [];
-  const headless = !!process.env.CI;
+  const headless = !!process.env.CI || undefined;
   server = await startTestAppServer(port);
   browser = await puppeteer.launch({
     headless,

--- a/adapters/selenium/src/index.ts
+++ b/adapters/selenium/src/index.ts
@@ -1,4 +1,4 @@
-import { Locator, UniDriverList, UniDriver, MapFn, waitFor, NoElementWithLocatorError, MultipleElementsWithLocatorError, isMultipleElementsWithLocatorError, EnterValueOptions } from '@unidriver/core';
+import { Locator, UniDriverList, UniDriver, MapFn, waitFor, NoElementWithLocatorError, MultipleElementsWithLocatorError, isMultipleElementsWithLocatorError, EnterValueOptions, DriverContext, contextToWaitError } from '@unidriver/core';
 import { By, WebElement, Key as SeleniumKey } from 'selenium-webdriver';
 
 export type WebElementGetter = () => Promise<WebElement>;
@@ -16,23 +16,32 @@ const interpolateSeleniumSpecialKeys = (key: string) => {
 };
 
 export const seleniumUniDriverList = (
-  wep: WebElementsGetter
+  wep: WebElementsGetter,
+  context: DriverContext = {selector: 'Root Selenium list driver'}
 ): UniDriverList<WebElement> => {
 
   const map = async <T>(fn: MapFn<T>) => {
     const els = await wep();
     const promises = els.map((e, i) => {
-      const bd = seleniumUniDriver(() => Promise.resolve(e));
+      const bd = seleniumUniDriver(() => Promise.resolve(e), {
+        parent: context,
+        idx: i,
+        selector: context.selector,
+      });
       return fn(bd, i);
     });
     return Promise.all(promises);
   };
 
   return {
-    get: (idx: number) => seleniumUniDriver(async () => {
-        const els = await wep();
-        return els[idx] as any;
-      }),
+    get: (idx: number) =>
+      seleniumUniDriver(
+        async () => {
+          const els = await wep();
+          return els[idx] as any;
+        },
+        { parent: context, selector: context.selector, idx }
+      ),
     text: async () => {
       return map((we) => we.text());
     },
@@ -45,8 +54,9 @@ export const seleniumUniDriverList = (
       return seleniumUniDriverList(async () => {
         const elems = await wep();
 
-        const results = await Promise.all(elems.map((e, i) => {
-            const bd = seleniumUniDriver(() => Promise.resolve(e));
+        const results = await Promise.all(
+          elems.map((e, i) => {
+            const bd = seleniumUniDriver(() => Promise.resolve(e), {parent: context, idx: i, selector: context.selector});
             return fn(bd, i);
           })
         );
@@ -54,12 +64,12 @@ export const seleniumUniDriverList = (
         return elems.filter((_, i) => {
           return results[i];
         });
-      });
-    }
+      }, context);
+    },
   };
 };
 
-export const seleniumUniDriver = (wep: WebElementGetter): UniDriver<WebElement> => {
+export const seleniumUniDriver = (wep: WebElementGetter, context: DriverContext = {selector: 'Root Selenium driver'}): UniDriver<WebElement> => {
 
 
   const elem = async () => {
@@ -93,20 +103,28 @@ export const seleniumUniDriver = (wep: WebElementGetter): UniDriver<WebElement> 
   };
 
   return {
-    $: (selector: Locator) => seleniumUniDriver(async () => {
-		const els = await (await elem()).findElements(By.css(selector));
-		if (els.length === 0) {
-			throw new NoElementWithLocatorError(selector);
-		} else if (els.length > 1) {
-			throw new MultipleElementsWithLocatorError(els.length, selector);
-		} else {
-			return els[0];
-		}
-      }),
-    $$: (selector: Locator) => seleniumUniDriverList(async () => {
-        const el = await elem();
-        return el.findElements(By.css(selector))
-      }),
+    $: (selector: Locator) =>
+      seleniumUniDriver(
+        async () => {
+          const els = await (await elem()).findElements(By.css(selector));
+          if (els.length === 0) {
+            throw new NoElementWithLocatorError(selector);
+          } else if (els.length > 1) {
+            throw new MultipleElementsWithLocatorError(els.length, selector);
+          } else {
+            return els[0];
+          }
+        },
+        { parent: context, selector: selector }
+      ),
+    $$: (selector: Locator) =>
+      seleniumUniDriverList(
+        async () => {
+          const el = await elem();
+          return el.findElements(By.css(selector));
+        },
+        { parent: context, selector: selector }
+      ),
     text: async () => {
       const el = await elem();
       return el.getText();
@@ -117,7 +135,7 @@ export const seleniumUniDriver = (wep: WebElementGetter): UniDriver<WebElement> 
     },
     value: async () => {
       const el = await elem();
-      return el.getAttribute('value');
+      return el.getAttribute("value");
     },
     click: async () => (await elem()).click(),
     hover: async () => {
@@ -128,28 +146,30 @@ export const seleniumUniDriver = (wep: WebElementGetter): UniDriver<WebElement> 
     },
     pressKey: async (key) => {
       const el = await elem();
-      const realKey = interpolateSeleniumSpecialKeys(camelCaseToHyphen(`${key}`).toUpperCase());
+      const realKey = interpolateSeleniumSpecialKeys(
+        camelCaseToHyphen(`${key}`).toUpperCase()
+      );
       const value = SeleniumKey[realKey as keyof typeof SeleniumKey] as string;
       if (value) {
         await el.sendKeys(value);
       } else {
-        return el.sendKeys(key); 
+        return el.sendKeys(key);
       }
     },
     hasClass: async (className: string) => {
       const el = await elem();
-      const cl = await el.getAttribute('class');
-      return cl.split(' ').includes(className);
+      const cl = await el.getAttribute("class");
+      return cl.split(" ").includes(className);
     },
     enterValue: async (
       value: string,
       { delay, shouldClear = true }: EnterValueOptions = {}
     ) => {
       const el = await elem();
-      const disabled = await el.getAttribute('disabled');
-			// Don't do anything if element is disabled
-			if (disabled) {
-				return;
+      const disabled = await el.getAttribute("disabled");
+      // Don't do anything if element is disabled
+      if (disabled) {
+        return;
       }
       if (shouldClear) {
         await el.clear();
@@ -164,28 +184,31 @@ export const seleniumUniDriver = (wep: WebElementGetter): UniDriver<WebElement> 
     isDisplayed: async () => {
       const el = await elem();
 
-			const retValue: boolean =
-				await el.getDriver().executeScript<boolean>(
-					'const elem = arguments[0], ' +
-					'			box = elem.getBoundingClientRect(), ' +
-					'			cx = box.left + box.width / 2, ' +
-					'			cy = box.top + box.height / 2, ' +
-					'			e = document.elementFromPoint(cx, cy); ' +
-					'		for (; e; e = e.parentElement) { ' +
-					'			if ( e === elem) return true; ' +
-					'		} ' +
-					'' +
-					'		return false;', el);
-			return retValue;
+      const retValue: boolean = await el
+        .getDriver()
+        .executeScript<boolean>(
+          "const elem = arguments[0], " +
+            "			box = elem.getBoundingClientRect(), " +
+            "			cx = box.left + box.width / 2, " +
+            "			cy = box.top + box.height / 2, " +
+            "			e = document.elementFromPoint(cx, cy); " +
+            "		for (; e; e = e.parentElement) { " +
+            "			if ( e === elem) return true; " +
+            "		} " +
+            "" +
+            "		return false;",
+          el
+        );
+      return retValue;
     },
     mouse: {
-			press: async() => {
+      press: async () => {
         const el = await elem();
         const driver = await el.getDriver();
         const actions = await driver.actions();
         await actions.mouseDown(el).perform();
-			},
-			release: async () => {
+      },
+      release: async () => {
         const el = await elem();
         const driver = await el.getDriver();
         const actions = await driver.actions();
@@ -197,20 +220,22 @@ export const seleniumUniDriver = (wep: WebElementGetter): UniDriver<WebElement> 
         const actions = await driver.actions();
         const native = await to.getNative();
         await actions.mouseMove(native).perform();
-			}
-		},
-		wait: async (timeout?: number) => {
-			return waitFor(exists, timeout);
-		},
-		type: 'selenium',
-		scrollIntoView: async () => {
-			const el = await elem();
-			return el.getDriver().executeScript('arguments[0].scrollIntoView();', el);
+      },
+    },
+    wait: async (timeout?: number) => {
+      return waitFor(exists, timeout, 30, contextToWaitError(context));
+    },
+    type: "selenium",
+    scrollIntoView: async () => {
+      const el = await elem();
+      return el.getDriver().executeScript("arguments[0].scrollIntoView();", el);
     },
     getNative: elem,
     _prop: async (name: string) => {
       const el = await elem();
-      return el.getDriver().executeScript('return arguments[0][arguments[1]];', el, name);
+      return el
+        .getDriver()
+        .executeScript("return arguments[0][arguments[1]];", el, name);
     },
   };
 };

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -75,6 +75,31 @@ export class MultipleElementsWithLocatorError extends Error {
 	}
 }
 
+export type DriverContext = {
+  parent?: DriverContext;
+  selector?: string;
+  idx?: number;
+};
+
+export const rootDriver: DriverContext = {
+	selector: ''
+}
+
+export const contextToSelectorString = (context: DriverContext): string => {
+	const maybeIndexDescription =
+    typeof context.idx === "number" && context.idx >= 0
+      	? ` at index #${context.idx}`
+		: "";
+	const maybeParentDescription = context.parent
+		? `${contextToSelectorString(context.parent)} => `
+		: "";
+  	return `${maybeParentDescription}${context.selector}${maybeIndexDescription}`;
+};
+
+export const contextToWaitError = (context: DriverContext): string => {
+	return `Timeout waiting for element: ${contextToSelectorString(context)}`;
+}
+
 export const isNoElementWithLocatorError = (e: Error): e is NoElementWithLocatorError => {
 	const type = (e as NoElementWithLocatorError).type || '';
 	return type === ErrorTypes.NO_ELEMENTS_WITH_SELECTOR;

--- a/test-suite/src/run-test-suite.ts
+++ b/test-suite/src/run-test-suite.ts
@@ -433,4 +433,60 @@ export const runTestSuite = (params: TestSuiteParams) => {
             });
         })
     });
+
+    describe('wait()', () => {
+        it('works for an element which already exists', async () => {
+            await runTest({ items: [itemCreator({ label: 'Bob', completed: true })] }, async (driver) => {
+                await driver.$('.todo-item').wait();
+            });
+        });
+
+        it(`throws an error containing the element's selector when an element does not exist`, async () => {
+            await runTest({ items: [] }, async (driver) => {
+                try {
+                    await driver.$('.todo-item').wait(10)
+                    assert.equal('should not', 'get here');
+                } catch (e) {
+                    assert.include(e.message, '.todo-item');
+                }
+            })
+        })
+
+        it(`throws an error containing the element's selector and index when it does not exist in a list`, async () => {
+            await runTest({ items: [] }, async (driver) => {
+                try {
+                    await driver.$$('.todo-item').get(7).wait(10)
+                    assert.equal('should not', 'get here');
+                } catch (e) {
+                    assert.include(e.message, '.todo-item');
+                    assert.include(e.message, '7');
+                }
+            })
+        })
+
+        it(`throws an error containing the element's parents selectors when it does not exist`, async () => {
+            await runTest({ items: [] }, async (driver) => {
+                try {
+                    await driver.$('.todo-app').$('.todo-item').wait(10);
+                    assert.equal('should not', 'get here');
+                } catch (e) {
+                    assert.include(e.message, '.todo-app');
+                    assert.include(e.message, '.todo-item');
+                }
+            })
+        })
+
+        it(`throws an error containing the element's parents selectors and index when it does not exist in a list`, async () => {
+          await runTest({ items: [] }, async (driver) => {
+            try {
+              await driver.$('.todo-app').$$(".todo-item").get(7).wait(10);
+              assert.equal("should not", "get here");
+            } catch (e) {
+              assert.include(e.message, ".todo-item");
+              assert.include(e.message, ".todo-app");
+              assert.include(e.message, "7");
+            }
+          });
+        });
+    });
 };


### PR DESCRIPTION
This PR addresess https://github.com/wix-incubator/unidriver/issues/118

1. Adds a `context` parameter to `driver` and `driverList` functions to track selector information.
2. Uses the context object to compose a clear message describing the element that was not found in `wait()`.