### PR TITLE
`@unidriver/jsdom-react"` - Improve stack trace for `NoElementWithLocatorError` thrown from `$`

### DIFF
--- a/adapters/jsdom-react/src/index.ts
+++ b/adapters/jsdom-react/src/index.ts
@@ -138,11 +138,13 @@ export const jsdomReactUniDriver = (containerOrFn: ElementOrElementFinder, conte
 
 	return {
 		$: (loc: Locator) => {
+			const noElementWithLocatorError = new NoElementWithLocatorError(loc);
+
 			const getElement = async () => {
 				const container = await elem();
 				const elements = container.querySelectorAll(loc);
 				if (!elements.length) {
-					throw new NoElementWithLocatorError(loc);
+					throw noElementWithLocatorError;
 				} else if (elements.length > 1) {
 					throw new MultipleElementsWithLocatorError(elements.length, loc);
 				}


### PR DESCRIPTION
Improve stack trace for error "Cannot find element with locator"


### Before
```
● Test suite failed to run

Error: Cannot find element with locator: [data-hook="collection-tablex"]

at getElement (../../../../node_modules/@unidriver/jsdom-react/src/index.ts:145:12)
```

### After
```
  ● Test suite failed to run

    Error: Cannot find element with locator: [data-hook="collection-tablex"]

       8 | ) {
       9 |   const collectionTable = CollectionTableUniDriver(
    > 10 |     base.$('[data-hook="collection-tablex"]'),
         |          ^
      11 |     body,
      12 |   );
      13 |

      at Object.$ (../../../../node_modules/@unidriver/jsdom-react/src/index.ts:141:10)
      at InfiniteScrollTableUniDriver (src/components/InfiniteScrollTable/InfiniteScrollTable.uni.driver.ts:10:10)
      at ../../../../node_modules/wix-ui-test-utils/src/vanilla/vanilla.tsx:61:12
      at InfiniteScrollTableDriver.getTable (src/__tests__/components/InfiniteScrollTable/InfiniteScrollTable.driver.tsx:101:12)
      at Object.<anonymous> (src/__tests__/components/InfiniteScrollTable/InfiniteScrollTable.actionsCell.spec.tsx:57:18)
```
