### PR TITLE
[puppeteer adapter] Move @types/puppeter to devDependencies

### DIFF
--- a/adapters/puppeteer/package.json
+++ b/adapters/puppeteer/package.json
@@ -1,31 +1,31 @@
 {
-	"name": "@unidriver/puppeteer",
-	"version": "2.2.0",
-	"description": "",
-	"main": "dist/index.js",
-	"typings": "dist/index.d.ts",
-	"scripts": {
-		"build": "rm -rf dist && tsc -p .",
-		"test": "mocha --timeout 20000 dist/**/*.spec.js"
-	},
-	"keywords": [],
-	"author": "Wix.com",
-	"license": "MIT",
-	"dependencies": {
-		"@types/puppeteer-core": "^5.4.0",
-		"@unidriver/core": "^1.3.0"
-	},
-	"devDependencies": {
-		"@unidriver/test-suite": "^1.3.0",
-		"find-free-port-sync": "^1.0.0",
-		"locate-chrome": "^0.1.1",
-		"mocha": "^6.0.0",
-		"puppeteer": "^5.5.0",
-		"puppeteer-core": "^10.1.0"
-	},
-	"peerDependencies": {
-		"puppeteer": "^5.5.0",
-		"puppeteer-core": "^10.1.0"
-	},
-	"gitHead": "c793eb6b7c1d687fe054bf47fb11224028b51f77"
+  "name": "@unidriver/puppeteer",
+  "version": "2.2.0",
+  "description": "",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
+  "scripts": {
+    "build": "rm -rf dist && tsc -p .",
+    "test": "mocha --timeout 20000 dist/**/*.spec.js"
+  },
+  "keywords": [],
+  "author": "Wix.com",
+  "license": "MIT",
+  "dependencies": {
+    "@unidriver/core": "^1.3.0"
+  },
+  "devDependencies": {
+    "@unidriver/test-suite": "^1.3.0",
+    "find-free-port-sync": "^1.0.0",
+    "locate-chrome": "^0.1.1",
+    "mocha": "^6.0.0",
+    "puppeteer": "^5.5.0",
+    "puppeteer-core": "^10.1.0",
+    "@types/puppeteer-core": "^5.4.0"
+  },
+  "peerDependencies": {
+    "puppeteer": "^5.5.0",
+    "puppeteer-core": "^10.1.0"
+  },
+  "gitHead": "c793eb6b7c1d687fe054bf47fb11224028b51f77"
 }


### PR DESCRIPTION
After some of the Wix infrastructure moved to puppeteer major version 14 - consumers started to get the type build failures on types mismatches. This adapter is cross major version compatible and should work fine with puppeteer 14 as there are no actual breaking changes for api that this adapter is using. 

**The short term** solution is to move `@types/puppeteer-core` to devDeps and unblock users from getting red builds.

**The long term** solution will be to upgrade this adapter to latest puppeteer and support backwards compatible api as long as possible.